### PR TITLE
Avoid git-clone with an invalid URL

### DIFF
--- a/normalize-git-url.js
+++ b/normalize-git-url.js
@@ -17,7 +17,7 @@ module.exports = function normalize (u) {
 
   // figure out what we should check out.
   var checkout = parsed.hash && parsed.hash.substr(1) || "master"
-  parsed.hash = ""
+  parsed.hash = null
 
   u = url.format(parsed)
   return {


### PR DESCRIPTION
ios.js: errounous hash appended on url.format
https://github.com/iojs/io.js/issues/1588
